### PR TITLE
Fix: regex in style for highlight color feature

### DIFF
--- a/src/color/converters/jsx/Text.tsx
+++ b/src/color/converters/jsx/Text.tsx
@@ -39,10 +39,10 @@ export const TextJSXConverter: JSXConverters<SerializedTextNode> = {
 		if (node.style) {
 			const style: React.CSSProperties = {}
 
-			let match = node.style.match(/background-color: ([^;]+)/)
+			let match = node.style.match(/^background-color: ([^;]+)/)
 			match && (style.backgroundColor = match[1]);
 
-			match = node.style.match(/color: ([^;]+)/)
+			match = node.style.match(/^color: ([^;]+)/)
 			match && (style.color = match[1]);
 
 			text = <span style={ style }>{text}</span>

--- a/src/color/converters/jsx/Text.tsx
+++ b/src/color/converters/jsx/Text.tsx
@@ -39,7 +39,7 @@ export const TextJSXConverter: JSXConverters<SerializedTextNode> = {
 		if (node.style) {
 			const style: React.CSSProperties = {}
 
-			let match = node.style.match(/^background-color: ([^;]+)/)
+			let match = node.style.match(/background-color: ([^;]+)/)
 			match && (style.backgroundColor = match[1]);
 
 			match = node.style.match(/^color: ([^;]+)/)

--- a/src/color/converters/jsx/Text.tsx
+++ b/src/color/converters/jsx/Text.tsx
@@ -39,10 +39,10 @@ export const TextJSXConverter: JSXConverters<SerializedTextNode> = {
 		if (node.style) {
 			const style: React.CSSProperties = {}
 
-			let match = node.style.match(/background-color: ([^;]+)/)
+			let match = node.style.match(/(?:^|;)\s?background-color: ([^;]+)/);
 			match && (style.backgroundColor = match[1]);
 
-			match = node.style.match(/^color: ([^;]+)/)
+			match = node.style.match(/(?:^|;)\s?color: ([^;]+)/);
 			match && (style.color = match[1]);
 
 			text = <span style={ style }>{text}</span>


### PR DESCRIPTION
This merge request fixes an issue in the regex used by the highlight color feature. The previous implementation caused the background color to override the text color, leading to unexpected behavior.

Changes:
Corrected the regex pattern to ensure proper differentiation between text and background color styling.

Impact:
This fix ensures that the highlight color functionality works as intended, preserving text color while applying background highlights.

Testing:
Manual testing to confirm text and background color remain distinct.