### PR TITLE
fix: @lexical/table version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"typescript": "^5.7.2"
 	},
 	"peerDependencies": {
-		"@lexical/table": "^0.20.0",
+		"@lexical/table": "^0.21.0",
 		"@payloadcms/richtext-lexical": "^3.0.0",
 		"escape-html": "^1.0.3"
 	}


### PR DESCRIPTION
Using @lexial/table version 0.20.0 creates a conflicting peer depencies between this package and @payloadcms/richtext-lexical which uses version 0.21.0

![CleanShot 2025-01-24 at 16 50 15](https://github.com/user-attachments/assets/1931ddef-fe06-46e5-a581-a2fa949f293b)
